### PR TITLE
Update from Kreate

### DIFF
--- a/composeApp/src/androidMain/kotlin/app/kreate/android/Threads.kt
+++ b/composeApp/src/androidMain/kotlin/app/kreate/android/Threads.kt
@@ -1,0 +1,20 @@
+package app.kreate.android
+
+import kotlinx.coroutines.asCoroutineDispatcher
+import java.util.concurrent.Executors
+
+/**
+ * Collection of useful threads.
+ *
+ * Must be closed individually after use to prevent unwanted outcome
+ */
+object Threads {
+
+    /**
+     * Single thread dispatcher guarantee jobs are
+     * executed in the order that were given to it.
+     *
+     * Should only be used by DataspecServices.kt
+     */
+    val DATASPEC_DISPATCHER = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+}

--- a/composeApp/src/androidMain/kotlin/app/kreate/android/themed/rimusic/screen/player/timeline/DurationIndicator.kt
+++ b/composeApp/src/androidMain/kotlin/app/kreate/android/themed/rimusic/screen/player/timeline/DurationIndicator.kt
@@ -198,7 +198,7 @@ fun DurationIndicator(
                 val positionAndDuration by binder.player.positionAndDurationState()
                 val timeRemaining by remember {
                     derivedStateOf {
-                        positionAndDuration.second - positionAndDuration.first
+                        (positionAndDuration.second - positionAndDuration.first).coerceAtLeast( 0 )
                     }
                 }
                 var isPaused by remember { mutableStateOf(false) }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/MainActivity.kt
@@ -93,6 +93,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.palette.graphics.Palette
 import app.kreate.android.BuildConfig
 import app.kreate.android.R
+import app.kreate.android.Threads
 import coil.imageLoader
 import coil.request.ImageRequest
 import com.kieronquinn.monetcompat.core.MonetActivityAccessException
@@ -1310,6 +1311,9 @@ class MainActivity :
         runCatching {
             monet.removeMonetColorsChangedListener(this)
             _monet = null
+
+            // Close threads
+            Threads.DATASPEC_DISPATCHER.close()
         }.onFailure {
             Timber.e("MainActivity.onDestroy removeMonetColorsChangedListener ${it.stackTraceToString()}")
         }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Queue.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Queue.kt
@@ -96,6 +96,7 @@ import it.fast4x.rimusic.utils.showButtonPlayerDiscoverKey
 import me.knighthat.component.SongItem
 import me.knighthat.component.tab.ExportSongsToCSVDialog
 import me.knighthat.component.tab.ItemSelector
+import me.knighthat.component.tab.Locator
 import me.knighthat.component.tab.Search
 import me.knighthat.component.ui.screens.player.DeleteFromQueue
 import me.knighthat.component.ui.screens.player.Discover
@@ -209,6 +210,7 @@ fun Queue(
             }
         )
         val queueArrow = QueueArrow { onDismiss( repeat.type ) }
+        val locator = Locator( lazyListState, ::getSongs )
 
         // Dialog renders
         exportDialog.Render()
@@ -424,6 +426,7 @@ fun Queue(
                         horizontalArrangement = Arrangement.End,
                         modifier = Modifier.weight( 1f ),
                         buttons = mutableListOf<Button>().apply {
+                            add( locator )
                             add( search )
                             if( rememberPreference( showButtonPlayerDiscoverKey, false ).value )
                                 add( discover )

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Queue.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Queue.kt
@@ -183,7 +183,6 @@ fun Queue(
             if( itemSelector.isEmpty() ) {
                 player.stop()
                 player.clearMediaItems()
-                player.release()
             } else
                 itemSelector.map( items::indexOf )
                             .sorted()

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/GetSeekBarType.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/GetSeekBarType.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -38,6 +39,7 @@ import androidx.compose.ui.graphics.StrokeJoin
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -307,19 +309,25 @@ fun GetSeekBar(
             modifier = Modifier.rotate( 180f )
                                .size( DURATION_INDICATOR_HEIGHT.dp )
                                .align( Alignment.CenterVertically )
-                               .pointerInput( position ) {
-                                   detectTapGestures(
-                                       onTap = {
-                                           binder.player.seekTo( position - 5000 )
-                                       },
-                                       onDoubleTap = {
-                                           binder.player.seekTo( position - 10_000 )
-                                       },
-                                       onLongPress = {
-                                           binder.player.seekTo( position - 30_000 )
-                                       }
-                                   )
-                               }
+                               .combinedClickable(
+                                   interactionSource = remember { MutableInteractionSource() },
+                                   indication = null,
+                                   role = Role.Button,
+                                   onClickLabel = "Rewind 5 seconds",
+                                   onClick = {
+                                       val newPosition = maxOf(position - 5000, 0)
+                                       binder.player.seekTo(newPosition)
+                                   },
+                                   onDoubleClick = {
+                                       val newPosition = maxOf(position - 10_000, 0)
+                                       binder.player.seekTo(newPosition)
+                                   },
+                                   onLongClickLabel = "Rewind 30 seconds",
+                                   onLongClick = {
+                                       val newPosition = maxOf(position - 30_000, 0)
+                                       binder.player.seekTo(newPosition)
+                                   }
+                               )
         )
 
         Spacer( Modifier.width( 5.dp ) )
@@ -481,19 +489,25 @@ fun GetSeekBar(
             tint = colorPalette().favoritesIcon,
             contentDescription = "Forward 5 seconds",
             modifier = Modifier.size( DURATION_INDICATOR_HEIGHT.dp )
-                               .pointerInput( position ) {
-                                   detectTapGestures(
-                                       onTap = {
-                                           binder.player.seekTo( position + 5000 )
-                                       },
-                                       onDoubleTap = {
-                                           binder.player.seekTo( position + 10_000 )
-                                       },
-                                       onLongPress = {
-                                           binder.player.seekTo( position + 30_000 )
-                                       }
-                                   )
-                               }
+                               .combinedClickable(
+                                   interactionSource = remember { MutableInteractionSource() },
+                                   indication =  null,
+                                   role = Role.Button,
+                                   onClickLabel = "Forward 5 seconds",
+                                   onClick = {
+                                       val newPosition = minOf(position + 5000, duration)
+                                       binder.player.seekTo(newPosition)
+                                   },
+                                   onDoubleClick = {
+                                       val newPosition = minOf( position + 10_000, duration )
+                                       binder.player.seekTo( newPosition )
+                                   },
+                                   onLongClickLabel = "Forward 30 seconds",
+                                   onLongClick = {
+                                       val newPosition = minOf( position + 30_000, duration )
+                                       binder.player.seekTo( newPosition )
+                                   }
+                               )
         )
     }
 }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/GetSeekBarType.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/GetSeekBarType.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.unit.dp
 import androidx.media3.common.C
 import androidx.media3.common.util.UnstableApi
 import app.kreate.android.R
+import app.kreate.android.themed.rimusic.screen.player.timeline.DurationIndicator
 import it.fast4x.rimusic.LocalPlayerServiceBinder
 import it.fast4x.rimusic.colorPalette
 import it.fast4x.rimusic.enums.ColorPaletteMode
@@ -90,7 +91,6 @@ fun GetSeekBar(
     LaunchedEffect(mediaId) {
         if (compositionLaunched) animatedPosition.animateTo(0f)
     }
-    val colorPaletteMode by rememberPreference(colorPaletteModeKey, ColorPaletteMode.Dark)
     LaunchedEffect(position) {
         if (!isSeeking && !animatedPosition.isRunning)
             animatedPosition.animateTo(
@@ -100,7 +100,6 @@ fun GetSeekBar(
                 )
             )
     }
-    val textoutline by rememberPreference(textoutlineKey, false)
 
     Row(
         horizontalArrangement = Arrangement.SpaceBetween,
@@ -290,224 +289,7 @@ fun GetSeekBar(
 
     }
 
-    Spacer(
-        modifier = Modifier
-            .height(8.dp)
-    )
+    Spacer( modifier = Modifier.height( 8.dp ) )
 
-    Row(
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier
-            .padding(horizontal = 10.dp)
-            .fillMaxWidth()
-    ) {
-        Icon(
-            painter = painterResource( R.drawable.play_forward ),
-            tint = colorPalette().favoritesIcon,
-            contentDescription = "Rewind 5 seconds",
-            modifier = Modifier.rotate( 180f )
-                               .size( DURATION_INDICATOR_HEIGHT.dp )
-                               .align( Alignment.CenterVertically )
-                               .combinedClickable(
-                                   interactionSource = remember { MutableInteractionSource() },
-                                   indication = null,
-                                   role = Role.Button,
-                                   onClickLabel = "Rewind 5 seconds",
-                                   onClick = {
-                                       val newPosition = maxOf(position - 5000, 0)
-                                       binder.player.seekTo(newPosition)
-                                   },
-                                   onDoubleClick = {
-                                       val newPosition = maxOf(position - 10_000, 0)
-                                       binder.player.seekTo(newPosition)
-                                   },
-                                   onLongClickLabel = "Rewind 30 seconds",
-                                   onLongClick = {
-                                       val newPosition = maxOf(position - 30_000, 0)
-                                       binder.player.seekTo(newPosition)
-                                   }
-                               )
-        )
-
-        Spacer( Modifier.width( 5.dp ) )
-
-        val outlineColor =
-            if ( colorPaletteMode == ColorPaletteMode.Light || (colorPaletteMode == ColorPaletteMode.System && !isSystemInDarkTheme()) )
-                Color.White.copy( 0.5f )
-            else if( !textoutline )
-                Color.Transparent
-            else
-                Color.Black
-
-        // Scrubbing position
-        Box(
-            modifier = Modifier.weight( 1f )
-                               .height( DURATION_INDICATOR_HEIGHT.dp ),
-            contentAlignment = Alignment.CenterStart
-        ) {
-            val toDisplay by remember( position ) {
-                derivedStateOf { formatAsDuration( scrubbingPosition ?: position ) }
-            }
-
-            // Main text
-            BasicText(
-                text = toDisplay,
-                style = typography().xxs.semiBold,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.clickable(
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = ripple(false),
-                    onClick = {binder.player.seekTo(position - 5000)}
-                )
-            )
-
-            // Outline (if applicable)
-            BasicText(
-                text = toDisplay,
-                style = typography().xxs
-                                    .semiBold
-                                    .merge(
-                                        TextStyle(
-                                            drawStyle = Stroke(width = 1.0f, join = StrokeJoin.Round),
-                                            color = outlineColor
-                                        )
-                                    ),
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        }
-
-        // Remaining duration
-        val showRemainingSongTime by rememberPreference( showRemainingSongTimeKey, true )
-        if( showRemainingSongTime ) {
-            Box(
-                modifier = Modifier.weight(1f)
-                                   .height(DURATION_INDICATOR_HEIGHT.dp),
-                contentAlignment = Alignment.Center
-            ) {
-                val positionAndDuration by binder.player.positionAndDurationState()
-                val timeRemaining by remember {
-                    derivedStateOf {
-                        positionAndDuration.second - positionAndDuration.first
-                    }
-                }
-                var isPaused by remember { mutableStateOf(false) }
-
-                val pauseBetweenSongs by rememberPreference(pauseBetweenSongsKey, PauseBetweenSongs.`0`)
-                if(pauseBetweenSongs != PauseBetweenSongs.`0`)
-                    LaunchedEffect(timeRemaining) {
-                        if(timeRemaining < 500) {
-                            isPaused = true
-                            binder.player.pause()
-                            delay(pauseBetweenSongs.asMillis)
-                            binder.player.play()
-                            isPaused = false
-                        }
-                    }
-
-                if(isPaused) return@Box
-
-                val toDisplay by remember {
-                    derivedStateOf { formatAsDuration(timeRemaining) }
-                }
-
-                // Main text
-                BasicText(
-                    text = toDisplay,
-                    style = typography().xxs.semiBold,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.clickable(
-                        interactionSource = remember { MutableInteractionSource() },
-                        indication = ripple(false),
-                        onClick = { binder.player.seekTo(position - 5000) }
-                    )
-                )
-
-                // Outline (if applicable)
-                BasicText(
-                    text = toDisplay,
-                    style = typography().xxs
-                                        .semiBold
-                                        .merge(
-                                            TextStyle(
-                                                drawStyle = Stroke(width = 1.0f, join = StrokeJoin.Round),
-                                                color = outlineColor
-                                            )
-                                        ),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
-        }
-
-        // Song's duration
-        Box(
-            modifier = Modifier.weight( 1f )
-                               .height( DURATION_INDICATOR_HEIGHT.dp ),
-            contentAlignment = Alignment.CenterEnd
-        ) {
-            val toDisplay = remember( duration ) {
-                if( duration <= 0 ) "--:--" else formatAsDuration( duration )
-            }
-
-            // Main text
-            BasicText(
-                text = toDisplay,
-                style = typography().xxs.semiBold,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.clickable(
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = ripple(false),
-                    onClick = {binder.player.seekTo(position - 5000)}
-                )
-            )
-
-            // Outline (if applicable)
-            BasicText(
-                text = toDisplay,
-                style = typography().xxs
-                                    .semiBold
-                                    .merge(
-                                        TextStyle(
-                                            drawStyle = Stroke(width = 1.0f, join = StrokeJoin.Round),
-                                            color = outlineColor
-                                        )
-                                    ),
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        }
-
-        Spacer( Modifier.width( 5.dp ) )
-
-        Icon(
-            painter = painterResource( R.drawable.play_forward ),
-            tint = colorPalette().favoritesIcon,
-            contentDescription = "Forward 5 seconds",
-            modifier = Modifier.size( DURATION_INDICATOR_HEIGHT.dp )
-                               .combinedClickable(
-                                   interactionSource = remember { MutableInteractionSource() },
-                                   indication =  null,
-                                   role = Role.Button,
-                                   onClickLabel = "Forward 5 seconds",
-                                   onClick = {
-                                       val newPosition = minOf(position + 5000, duration)
-                                       binder.player.seekTo(newPosition)
-                                   },
-                                   onDoubleClick = {
-                                       val newPosition = minOf( position + 10_000, duration )
-                                       binder.player.seekTo( newPosition )
-                                   },
-                                   onLongClickLabel = "Forward 30 seconds",
-                                   onLongClick = {
-                                       val newPosition = minOf( position + 30_000, duration )
-                                       binder.player.seekTo( newPosition )
-                                   }
-                               )
-        )
-    }
+    DurationIndicator( binder, scrubbingPosition, position, duration )
 }


### PR DESCRIPTION
✅ Fixes
Remaining time still shown even when disabled.
Forward/Rewind buttons act weird after multiple clicks.
Prevent remaining time from displaying large negative values.
Player was being released when a song was deleted from the queue — fixed.

🧠 Refactoring
Moved song info fetch logic out of getFormatUrl.
Extracted duration indicator logic into a separate function.
Extracted skip time button into its own function.
Extracted outlined text rendering into its own function.

➕ Enhancements
Added a locator button to queue actions (UX improvement).